### PR TITLE
Implemented IntoIterator for MultiMap (ref, mut ref and consuming)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -491,6 +491,18 @@ impl<'a, K, V> IntoIterator for &'a MultiMap<K, V>
     }
 }
 
+impl<'a, K, V> IntoIterator for &'a mut MultiMap<K, V>
+    where K: Eq + Hash
+{
+
+    type Item = (&'a K, &'a mut Vec<V>);
+    type IntoIter = IterAllMut<'a, K, Vec<V>>;
+
+    fn into_iter(mut self) -> IterAllMut<'a, K, Vec<V>> {
+        self.inner.iter_mut()
+    }
+}
+
 impl<K, V> IntoIterator for MultiMap<K, V>
     where K: Eq + Hash
 {
@@ -746,6 +758,31 @@ fn intoiterator_for_reference_type() {
             assert_eq!(value, &vec![42]);
         }
     }
+}
+
+#[test]
+fn intoiterator_for_mutable_reference_type() {
+    let mut m: MultiMap<usize, usize> = MultiMap::new();
+    m.insert(1,42);
+    m.insert(1,43);
+    m.insert(4,42);
+    m.insert(8,42);
+
+    let keys = vec![1,4,8];
+
+    for (key, value) in &mut m {
+        assert!(keys.contains(key));
+
+        if key == &1 {
+            assert_eq!(value, &vec![42, 43]);
+            value.push(666);
+        }
+        else {
+            assert_eq!(value, &vec![42]);
+        }
+    }
+
+    assert_eq!(m.get_vec(&1), Some(&vec![42, 43, 666]));
 }
 
 #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,11 +483,11 @@ impl<K, V> Eq for MultiMap<K, V> where K: Eq + Hash, V: Eq {}
 impl<'a, K, V> IntoIterator for &'a MultiMap<K, V>
     where K: Eq + Hash
 {
-    type Item = (&'a K, &'a V);
-    type IntoIter = Iter<'a, K, V>;
-    
-    fn into_iter(self) -> Iter<'a, K, V> {
-        self.iter()
+    type Item = (&'a K, &'a Vec<V>);
+    type IntoIter = IterAll<'a, K, Vec<V>>;
+
+    fn into_iter(self) -> IterAll<'a, K, Vec<V>> {
+        self.iter_all()
     }
 }
 
@@ -722,12 +722,18 @@ fn intoiterator_for_reference_type() {
     m.insert(1,43);
     m.insert(4,42);
     m.insert(8,42);
-    
+
     let keys = vec![1,4,8];
-    
+
     for (key, value) in &m {
         assert!(keys.contains(key));
-        assert_eq!(value, &42)
+
+        if key == &1 {
+            assert_eq!(value, &vec![42, 43]);
+        }
+        else {
+            assert_eq!(value, &vec![42]);
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 use std::collections::HashMap;
-use std::collections::hash_map::Keys;
+use std::collections::hash_map::{Keys, IntoIter};
 use std::fmt::{self, Debug};
 use std::iter::{Iterator, IntoIterator};
 use std::hash::Hash;
@@ -491,6 +491,17 @@ impl<'a, K, V> IntoIterator for &'a MultiMap<K, V>
     }
 }
 
+impl<K, V> IntoIterator for MultiMap<K, V>
+    where K: Eq + Hash
+{
+    type Item = (K, Vec<V>);
+    type IntoIter = IntoIter<K, Vec<V>>;
+
+    fn into_iter(self) -> IntoIter<K, Vec<V>> {
+        self.inner.into_iter()
+    }
+}
+
 #[derive(Clone)]
 pub struct Iter<'a, K: 'a, V: 'a> {
     inner: IterAll<'a,K, Vec<V>>,
@@ -733,6 +744,28 @@ fn intoiterator_for_reference_type() {
         }
         else {
             assert_eq!(value, &vec![42]);
+        }
+    }
+}
+
+#[test]
+fn intoiterator_consuming() {
+    let mut m: MultiMap<usize, usize> = MultiMap::new();
+    m.insert(1,42);
+    m.insert(1,43);
+    m.insert(4,42);
+    m.insert(8,42);
+
+    let keys = vec![1,4,8];
+
+    for (key, value) in m {
+        assert!(keys.contains(&key));
+
+        if key == 1 {
+            assert_eq!(value, vec![42, 43]);
+        }
+        else {
+            assert_eq!(value, vec![42]);
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::collections::hash_map::Keys;
 use std::fmt::{self, Debug};
-use std::iter::Iterator;
+use std::iter::{Iterator, IntoIterator};
 use std::hash::Hash;
 use std::ops::Index;
 
@@ -480,6 +480,17 @@ impl<K, V> PartialEq for MultiMap<K, V> where K: Eq + Hash, V: PartialEq {
 
 impl<K, V> Eq for MultiMap<K, V> where K: Eq + Hash, V: Eq {}
 
+impl<'a, K, V> IntoIterator for &'a MultiMap<K, V>
+    where K: Eq + Hash
+{
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+    
+    fn into_iter(self) -> Iter<'a, K, V> {
+        self.iter()
+    }
+}
+
 #[derive(Clone)]
 pub struct Iter<'a, K: 'a, V: 'a> {
     inner: IterAll<'a,K, Vec<V>>,
@@ -702,6 +713,22 @@ fn iter() {
     for _ in iter.by_ref().take(2) {}
 
     assert_eq!(iter.len(), 1);
+}
+
+#[test]
+fn intoiterator_for_reference_type() {
+    let mut m: MultiMap<usize, usize> = MultiMap::new();
+    m.insert(1,42);
+    m.insert(1,43);
+    m.insert(4,42);
+    m.insert(8,42);
+    
+    let keys = vec![1,4,8];
+    
+    for (key, value) in &m {
+        assert!(keys.contains(key));
+        assert_eq!(value, &42)
+    }
 }
 
 #[test]


### PR DESCRIPTION
For &MultiMap this implementation makes sense, but for the consuming IntoIterator (for MultiMap) this api will lose the vector of values. So maybe the IntoIterator's should use iter_all() instead.

Either ...

``` rust
for (key, first_value_in_vec) in multimap {}
```

... or:

``` rust
for (key, vector_of_values) in multimap {}
```
