### PR TITLE
Add #![forbid(unsafe_code)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(unsafe_code)]
 // Copyright (c) 2016 multimap developers
 //
 // Licensed under the Apache License, Version 2.0


### PR DESCRIPTION
Since this crate uses no unsafe, it would make sense to signal that to geiger loving folk by adding `#![forbid(unsafe_code)]` for fee.