### PR TITLE
Small tweaks to the `multimap!()` macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "multimap"
-version = "0.8.2"
+version = "0.8.3"
 description = "A multimap implementation."
 readme = "README.md"
 repository = "https://github.com/havarnov/multimap"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -875,9 +875,12 @@ impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {
 ///
 /// ```
 macro_rules! multimap{
-    ($($key:expr => $value:expr),*)=>{
+    (@replace_with_unit $_t:tt) => { () };
+    (@count $($key:expr),*) => { <[()]>::len(&[$($crate::multimap! { @replace_with_unit $key }),*]) };
+    
+    ($($key:expr => $value:expr),* $(,)?)=>{
         {
-            let mut map = MultiMap::new();
+            let mut map = $crate::MultiMap::with_capacity($crate::multimap! { @count $($key),* });
             $(
                 map.insert($key,$value);
              )*


### PR DESCRIPTION
 1. Allow trailing comma.
 2. Prefix `MultiMap` with `$crate::` so there won't be name clash (see https://doc.rust-lang.org/reference/macros-by-example.html#hygiene).
 3. Instantiate the map with enough capacity to hold the elements, preventing further allocations (for the actual counting method, see https://danielkeep.github.io/tlborm/book/blk-counting.html#slice-length).