### PR TITLE
Added flat iterators.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -625,11 +625,8 @@ where
     ///     println!("key: {:?}, val: {:?}", key, value);
     /// }
     /// ```
-    pub fn flat_iter(&self) -> FlatIter<K, V> {
-        FlatIter {
-            inner: self.inner.iter(),
-            inner_iter: None,
-        }
+    pub fn flat_iter(&self) -> impl Iterator<Item = (&K, &V)> {
+        self.iter_all().flat_map(|(k, v)| v.into_iter().map(move |i| (k, i)))
     }
 
     /// An iterator visiting all key-value pairs in arbitrary order. The iterator returns
@@ -651,11 +648,8 @@ where
     ///     println!("key: {:?}, val: {:?}", key, value);
     /// }
     /// ```
-    pub fn flat_iter_mut(&mut self) -> FlatIterMut<K, V> {
-        FlatIterMut {
-            inner: self.inner.iter_mut(),
-            inner_iter: None,
-        }
+    pub fn flat_iter_mut(&mut self) -> impl Iterator<Item = (&K, &mut V)> {
+        self.iter_all_mut().flat_map(|(k, v)| v.into_iter().map(move |i| (k, i)))
     }
 
     /// Gets the specified key's corresponding entry in the map for in-place manipulation.
@@ -940,63 +934,6 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
 impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {
     fn len(&self) -> usize {
         self.inner.len()
-    }
-}
-
-#[derive(Clone)]
-pub struct FlatIter<'a, K: 'a, V: 'a> {
-    inner: IterAll<'a, K, Vec<V>>,
-    inner_iter: Option<(&'a K, std::slice::Iter<'a, V>)>,
-}
-
-impl<'a, K, V> Iterator for FlatIter<'a, K, V> {
-    type Item = (&'a K, &'a V);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some((ref k, ref mut iter)) = self.inner_iter {
-            match iter.next() {
-                Some(v) => return Some((k, v)),
-                None => self.inner_iter = None,
-            }
-        }
-        match self.inner.next() {
-            Some((k, vec)) if vec.len() == 1 => Some((k, &vec[0])),
-            Some((k, vec)) => {
-                let mut iter = vec.iter();
-                let v = iter.next().unwrap();
-                self.inner_iter = Some((k, iter));
-                Some((k, v))
-            },
-            _ => None,
-        }
-    }
-}
-
-pub struct FlatIterMut<'a, K: 'a, V: 'a> {
-    inner: IterAllMut<'a, K, Vec<V>>,
-    inner_iter: Option<(&'a K, std::slice::IterMut<'a, V>)>,
-}
-
-impl<'a, K, V> Iterator for FlatIterMut<'a, K, V> {
-    type Item = (&'a K, &'a mut V);
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if let Some((ref k, ref mut iter)) = self.inner_iter {
-            match iter.next() {
-                Some(v) => return Some((k, v)),
-                None => self.inner_iter = None,
-            }
-        }
-        match self.inner.next() {
-            Some((k, vec)) if vec.len() == 1 => Some((k, &mut vec[0])),
-            Some((k, vec)) => {
-                let mut iter = vec.iter_mut();
-                let v = iter.next().unwrap();
-                self.inner_iter = Some((k, iter));
-                Some((k, v))
-            },
-            _ => None,
-        }
     }
 }
 


### PR DESCRIPTION
I couldn't figure out an easy way to simply iterate over all the individual items. I didn't want the vectors of multi-valued items; I wanted to visit each item, even if I got the same key for multiple values.

So, the typical example:
```
    let mut map = MultiMap::new();
    map.insert(1,42);
    map.insert(1,1337);
    map.insert(3,2332);
    map.insert(4,1991);

    for (key, value) in map.flat_iter() {
        println!("key: {:?}, val: {:?}", key, value);
    }
```
would produce:
```
key: 1, val: 42
key: 1, val: 1337
key: 3, val: 2332
key: 4, val: 1991
```
If there's an existing or better way to do this or a more efficient way to implement it, let me know!