### PR TITLE
[smallvec] Fix all tests and take smallvec size as const parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ default = ["serde_impl"]
 
 [dependencies]
 serde = { version = "~1.0", optional = true }
-smallvec = "1.8.0"
+smallvec = { version = "1.8.0", features = ["union", "const_generics"] }
 
 [dev-dependencies]
 serde_test = "~1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ where
         K: Borrow<Q>,
         Q: Eq + Hash,
     {
-        self.inner.get(k).map(|v| &v[0])
+        self.inner.get(k)?.get(0)
     }
 
     /// Returns a mutable reference to the first item in the vector corresponding to
@@ -351,7 +351,7 @@ where
         K: Borrow<Q>,
         Q: Eq + Hash,
     {
-        self.inner.get_mut(k).map(|v| v.get_mut(0).unwrap())
+        self.inner.get_mut(k)?.get_mut(0)
     }
 
     /// Returns a reference to the vector corresponding to the key.
@@ -1078,6 +1078,14 @@ mod tests {
     }
 
     #[test]
+    fn get_empty() {
+        let mut m: MultiMap<usize, usize> = MultiMap::new();
+        m.insert(1, 42);
+        m.get_vec_mut(&1).and_then(Vec::pop);
+        assert_eq!(m.get(&1), None);
+    }
+
+    #[test]
     fn get_vec_not_present() {
         let m: MultiMap<usize, usize> = MultiMap::new();
         assert_eq!(m.get_vec(&1), None);
@@ -1138,6 +1146,14 @@ mod tests {
             (*v)[1] = 10;
         }
         assert_eq!(m.get_vec(&1), Some(&vec![5, 10]))
+    }
+
+    #[test]
+    fn get_mut_empty() {
+        let mut m: MultiMap<usize, usize> = MultiMap::new();
+        m.insert(1, 42);
+        m.get_vec_mut(&1).and_then(Vec::pop);
+        assert_eq!(m.get_mut(&1), None);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -631,7 +631,7 @@ where
     ///     assert_eq!(v, &vec![44]);
     ///     v.push(50);
     /// }
-    /// assert_eq!(m.entry(2).or_insert_vec(vec![666]), &vec![666]);
+    /// assert_eq!(m.entry(2).or_insert_vec(vec![667]), &vec![666]);
     ///
     /// assert_eq!(m.get_vec(&1), Some(&vec![44, 50]));
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -489,12 +489,13 @@ where
     ///
     /// let mut map = MultiMap::new();
     /// map.insert(1,42);
+    /// map.insert(1,1337);
     /// map.insert(2,1337);
     /// map.insert(4,1991);
     ///
-    /// for key in map.keys() {
-    ///     println!("{:?}", key);
-    /// }
+    /// let mut keys: Vec<_> = map.keys().collect();
+    /// keys.sort();
+    /// assert_eq!(keys, [&1, &2, &4]);
     /// ```
     pub fn keys(&'_ self) -> Keys<'_, K, Vec<V>> {
         self.inner.keys()
@@ -515,9 +516,9 @@ where
     /// map.insert(3,2332);
     /// map.insert(4,1991);
     ///
-    /// for (key, value) in map.iter() {
-    ///     println!("key: {:?}, val: {:?}", key, value);
-    /// }
+    /// let mut pairs: Vec<_> = map.iter().collect();
+    /// pairs.sort_by_key(|p| p.0);
+    /// assert_eq!(pairs, [(&1, &42), (&3, &2332), (&4, &1991)]);
     /// ```
     pub fn iter(&self) -> Iter<K, V> {
         Iter {
@@ -544,9 +545,9 @@ where
     ///     *value *= *value;
     /// }
     ///
-    /// for (key, value) in map.iter() {
-    ///     println!("key: {:?}, val: {:?}", key, value);
-    /// }
+    /// let mut pairs: Vec<_> = map.iter_mut().collect();
+    /// pairs.sort_by_key(|p| p.0);
+    /// assert_eq!(pairs, [(&1, &mut 1764), (&3, &mut 5438224), (&4, &mut 3964081)]);
     /// ```
     pub fn iter_mut(&mut self) -> IterMut<K, V> {
         IterMut {
@@ -569,9 +570,9 @@ where
     /// map.insert(3,2332);
     /// map.insert(4,1991);
     ///
-    /// for (key, values) in map.iter_all() {
-    ///     println!("key: {:?}, values: {:?}", key, values);
-    /// }
+    /// let mut pairs: Vec<_> = map.iter_all().collect();
+    /// pairs.sort_by_key(|p| p.0);
+    /// assert_eq!(pairs, [(&1, &vec![42, 1337]), (&3, &vec![2332]), (&4, &vec![1991])]);
     /// ```
     pub fn iter_all(&self) -> IterAll<K, Vec<V>> {
         self.inner.iter()
@@ -598,9 +599,9 @@ where
     ///     }
     /// }
     ///
-    /// for (key, values) in map.iter_all() {
-    ///     println!("key: {:?}, values: {:?}", key, values);
-    /// }
+    /// let mut pairs: Vec<_> = map.iter_all_mut().collect();
+    /// pairs.sort_by_key(|p| p.0);
+    /// assert_eq!(pairs, [(&1, &mut vec![99, 99]), (&3, &mut vec![99]), (&4, &mut vec![99])]);
     /// ```
     pub fn iter_all_mut(&mut self) -> IterAllMut<K, Vec<V>> {
         self.inner.iter_mut()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -667,7 +667,7 @@ where
         for (key, vector) in &mut self.inner {
             vector.retain(|value| f(key, value));
         }
-        self.inner.retain(|&_, ref v| !v.is_empty());
+        self.inner.retain(|_, v| !v.is_empty());
     }
 }
 
@@ -1260,11 +1260,11 @@ mod tests {
         let mut m2 = MultiMap::new();
         m2.insert(1, 2);
         m2.insert(2, 3);
-        assert!(m1 != m2);
+        assert_ne!(m1, m2);
         m2.insert(3, 4);
         assert_eq!(m1, m2);
         m2.insert(3, 4);
-        assert!(m1 != m2);
+        assert_ne!(m1, m2);
         m1.insert(3, 4);
         assert_eq!(m1, m2);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,14 +7,16 @@
 // option. All files in the project carrying such notice may not be copied,
 // modified, or distributed except according to those terms.
 
-//! A MultiMap implementation which is just a wrapper around std::collections::HashMap.
-//! See HashMap's documentation for more details.
+//! A map implementation which allows storing multiple values per key.
 //!
-//! Some of the methods are just thin wrappers, some methods does change a little semantics
-//! and some methods are new (doesn't have an equivalent in HashMap.)
+//! The interface is roughly based on std::collections::HashMap, but is changed
+//! and extended to accomodate the multi-value use case. In fact, MultiMap is
+//! implemented mostly as a thin wrapper around std::collections::HashMap and
+//! stores its values as a std::Vec per key.
 //!
-//! The MultiMap is generic for the key (K) and the value (V). Internally the values are
-//! stored in a generic Vector.
+//! Values are guaranteed to be in insertion order as long as not manually
+//! changed. Keys are not ordered. Multiple idential key-value-pairs can exist
+//! in the MultiMap. A key can exist in the MultiMap with no associated value.
 //!
 //! # Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -957,6 +957,14 @@ mod tests {
     }
 
     #[test]
+    fn insert_identical() {
+        let mut m = MultiMap::new();
+        m.insert(1, 42);
+        m.insert(1, 42);
+        assert_eq!(m.get_vec(&1), Some(&vec![42, 42]));
+    }
+
+    #[test]
     fn insert_many() {
         let mut m: MultiMap<usize, usize> = MultiMap::new();
         m.insert_many(1, vec![3, 4]);
@@ -969,6 +977,14 @@ mod tests {
         m.insert(1, 2);
         m.insert_many(1, vec![3, 4]);
         assert_eq!(Some(&vec![2, 3, 4]), m.get_vec(&1));
+    }
+
+    #[test]
+    fn insert_many_overlap() {
+        let mut m: MultiMap<usize, usize> = MultiMap::new();
+        m.insert_many(1, vec![2, 3]);
+        m.insert_many(1, vec![3, 4]);
+        assert_eq!(Some(&vec![2, 3, 3, 4]), m.get_vec(&1));
     }
 
     #[test]
@@ -991,6 +1007,7 @@ mod tests {
         let mut m: MultiMap<usize, usize> = MultiMap::new();
         m.insert(1, 3);
         m.insert(1, 4);
+        assert_eq!(Some(&vec![3, 4]), m.get_vec(&1));
     }
 
     #[test]
@@ -1249,6 +1266,19 @@ mod tests {
         m2.insert(3, 4);
         assert!(m1 != m2);
         m1.insert(3, 4);
+        assert_eq!(m1, m2);
+    }
+
+    #[test]
+    fn test_eq_empty_key() {
+        let mut m1 = MultiMap::new();
+        m1.insert(1, 2);
+        m1.insert(2, 3);
+        let mut m2 = MultiMap::new();
+        m2.insert(1, 2);
+        m2.insert_many(2, []);
+        assert_ne!(m1, m2);
+        m2.insert_many(2, [3]);
         assert_eq!(m1, m2);
     }
 


### PR DESCRIPTION
This removes the .get_vec() and .get_vec_mut() functions in favor of .get_slice() and .get_slice_mut() functions that return slices. This does break the API.

I'm not an expert in Rust, so any feedback is welcome, even if you don't want to merge this.