### PR TITLE
Avoid allocating for single values by using an enum

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -8,17 +8,111 @@
 
 use std::collections::hash_map::OccupiedEntry as HashMapOccupiedEntry;
 use std::collections::hash_map::VacantEntry as HashMapVacantEntry;
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::slice;
+
+pub enum OneOrAny<T> {
+    One(T),
+    Any(Vec<T>),
+}
+
+impl<T> Default for OneOrAny<T> {
+    fn default() -> Self {
+        OneOrAny::Any(Vec::new())
+    }
+}
+
+impl<T> From<T> for OneOrAny<T> {
+    fn from(one: T) -> Self {
+        OneOrAny::One(one)
+    }
+}
+
+impl<T> From<Vec<T>> for OneOrAny<T> {
+    fn from(any: Vec<T>) -> Self {
+        OneOrAny::Any(any)
+    }
+}
+
+impl<T: Clone> Clone for OneOrAny<T> {
+    fn clone(&self) -> Self {
+        match self {
+            OneOrAny::One(ref one) => OneOrAny::One(one.clone()),
+            OneOrAny::Any(any) if any.len() == 1 => OneOrAny::One(any[0].clone()),
+            OneOrAny::Any(any) => OneOrAny::Any(any.clone()),
+        }
+    }
+}
+
+impl<T> OneOrAny<T> {
+    pub fn retain<F: FnMut(&T)->bool>(&mut self,  mut f: F) {
+        match self {
+            OneOrAny::One(ref mut value) if f(value) => {},
+            OneOrAny::One(_) => *self = Self::default(),
+            OneOrAny::Any(ref mut values) => values.retain(f),
+        }
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        match self {
+            OneOrAny::One(ref value) => slice::from_ref(value),
+            OneOrAny::Any(ref values) => values,
+        }
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut[T] {
+        match self {
+            OneOrAny::One(ref mut value) => slice::from_mut(value),
+            OneOrAny::Any(ref mut values) => values,
+        }
+    }
+
+    pub fn as_mut_vec(&mut self) -> &mut Vec<T> {
+        if let OneOrAny::Any(any) = self {
+            any
+        } else {
+            let moved = mem::replace(self, OneOrAny::Any(Vec::with_capacity(1)));
+            let OneOrAny::One(value) = moved else {unreachable!()};
+            let OneOrAny::Any(slot) = self else {unreachable!()};
+            slot.push(value);
+            slot
+        }
+    }
+}
+
+impl<T> Deref for OneOrAny<T> {
+    type Target = [T];
+    fn deref(&self) -> &[T] {
+        self.as_slice()
+    }
+}
+
+impl<T> DerefMut for OneOrAny<T> {
+    fn deref_mut(&mut self) -> &mut[T] {
+        self.as_mut_slice()
+    }
+}
+
+impl<T> From<OneOrAny<T>> for Vec<T> {
+    fn from(values: OneOrAny<T>) -> Vec<T> {
+        match values {
+            OneOrAny::One(value) => vec![value],
+            OneOrAny::Any(values) => values,
+        }
+    }
+}
 
 /// A view into a single occupied location in a MultiMap.
 pub struct OccupiedEntry<'a, K: 'a, V: 'a> {
     #[doc(hidden)]
-    pub inner: HashMapOccupiedEntry<'a, K, Vec<V>>,
+    pub inner: HashMapOccupiedEntry<'a, K, OneOrAny<V>>,
 }
 
 /// A view into a single empty location in a MultiMap.
 pub struct VacantEntry<'a, K: 'a, V: 'a> {
     #[doc(hidden)]
-    pub inner: HashMapVacantEntry<'a, K, Vec<V>>,
+    pub inner: HashMapVacantEntry<'a, K, OneOrAny<V>>,
 }
 
 /// A view into a single location in a map, which may be vacant or occupied.
@@ -48,7 +142,7 @@ impl<'a, K: 'a, V: 'a> OccupiedEntry<'a, K, V> {
 
     /// Gets a mut reference to the values (vector) corresponding to entry.
     pub fn get_vec_mut(&mut self) -> &mut Vec<V> {
-        self.inner.get_mut()
+        self.inner.get_mut().as_mut_vec()
     }
 
     /// Converts the OccupiedEntry into a mutable reference to the first item in value in the entry
@@ -60,7 +154,7 @@ impl<'a, K: 'a, V: 'a> OccupiedEntry<'a, K, V> {
     /// Converts the OccupiedEntry into a mutable reference to the values (vector) in the entry
     /// with a lifetime bound to the map itself
     pub fn into_vec_mut(self) -> &'a mut Vec<V> {
-        self.inner.into_mut()
+        self.inner.into_mut().as_mut_vec()
     }
 
     /// Inserts a new value onto the vector of the entry.
@@ -75,7 +169,7 @@ impl<'a, K: 'a, V: 'a> OccupiedEntry<'a, K, V> {
 
     /// Takes the values (vector) out of the entry, and returns it
     pub fn remove(self) -> Vec<V> {
-        self.inner.remove()
+        self.inner.remove().into()
     }
 }
 
@@ -83,13 +177,13 @@ impl<'a, K: 'a, V: 'a> VacantEntry<'a, K, V> {
     /// Sets the first value in the vector of the entry with the VacantEntry's key,
     /// and returns a mutable reference to it.
     pub fn insert(self, value: V) -> &'a mut V {
-        &mut self.inner.insert(vec![value])[0]
+        &mut self.inner.insert(OneOrAny::One(value))[0]
     }
 
     /// Sets values in the entry with the VacantEntry's key,
     /// and returns a mutable reference to it.
     pub fn insert_vec(self, values: Vec<V>) -> &'a mut Vec<V> {
-        self.inner.insert(values)
+        self.inner.insert(OneOrAny::Any(values)).as_mut_vec()
     }
 }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -37,7 +37,7 @@ impl<'a, K: 'a, V: 'a> OccupiedEntry<'a, K, V> {
     }
 
     /// Gets a reference to the values (vector) corresponding to entry.
-    pub fn get_vec(&self) -> &Vec<V> {
+    pub fn get_slice(&self) -> &[V] {
         self.inner.get()
     }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -18,6 +18,31 @@ use self::serde::de::{MapAccess, Visitor};
 use self::serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use MultiMap;
+use entry::OneOrAny;
+
+impl<T> Serialize for OneOrAny<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.as_slice().serialize(serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for OneOrAny<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Vec::<T>::deserialize(deserializer).map(OneOrAny::Any)
+    }
+}
 
 impl<K, V, BS> Serialize for MultiMap<K, V, BS>
 where


### PR DESCRIPTION
This is a breaking change:

- Renames `get_vec()` to `get_slice()` and makes it return `&[V]`.
- Makes `iter_all()` and `iter_all_mut()` produce slices instead of vectors.
- Changes `IterAll` and `IterAllMut` from being re-exports to structs.

Tests are passing but docs have mostly not been updated.