### PR TITLE
Fix or document panics when the vector for a key is empty

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -32,8 +32,12 @@ pub enum Entry<'a, K: 'a, V: 'a> {
 
 impl<'a, K: 'a, V: 'a> OccupiedEntry<'a, K, V> {
     /// Gets a reference to the first item in value in the vector corresponding to entry.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the key has zero values.
     pub fn get(&self) -> &V {
-        &self.inner.get()[0]
+        self.inner.get().first().expect("no values in entry")
     }
 
     /// Gets a reference to the values (vector) corresponding to entry.
@@ -42,8 +46,15 @@ impl<'a, K: 'a, V: 'a> OccupiedEntry<'a, K, V> {
     }
 
     /// Gets a mut reference to the first item in value in the vector corresponding to entry.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the key has zero values.
     pub fn get_mut(&mut self) -> &mut V {
-        &mut self.inner.get_mut()[0]
+        self.inner
+            .get_mut()
+            .first_mut()
+            .expect("no values in entry")
     }
 
     /// Gets a mut reference to the values (vector) corresponding to entry.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -732,8 +732,9 @@ where
     fn index(&self, index: &Q) -> &V {
         self.inner
             .get(index)
-            .map(|v| &v[0])
             .expect("no entry found for key")
+            .first()
+            .expect("no value found for key")
     }
 }
 
@@ -1065,7 +1066,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
+    #[should_panic(expected = "no entry found for key")]
     fn index_no_entry() {
         let m: MultiMap<usize, usize> = MultiMap::new();
         let _ = &m[&1];
@@ -1074,7 +1075,19 @@ mod tests {
     #[test]
     fn index() {
         let mut m: MultiMap<usize, usize> = MultiMap::new();
+        m.insert(1, 41);
+        m.insert(2, 42);
+        m.insert(3, 43);
+        let values = m[&2];
+        assert_eq!(values, 42);
+    }
+
+    #[test]
+    #[should_panic(expected = "no value found for key")]
+    fn index_empty_vec() {
+        let mut m: MultiMap<usize, usize> = MultiMap::new();
         m.insert(1, 42);
+        m.get_vec_mut(&1).unwrap().clear();
         let values = m[&1];
         assert_eq!(values, 42);
     }


### PR DESCRIPTION
Inspired by #36.

I saw the iterator bugs when working on #43, and found the rest by searching for `[0]`.