### PR TITLE
Fix several clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1290,7 +1290,7 @@ mod tests {
         m.insert(4, 42);
         m.insert(8, 42);
 
-        let keys = vec![1, 4, 8];
+        let keys = [1, 4, 8];
 
         for (key, value) in m.flat_iter() {
             assert!(keys.contains(key));
@@ -1311,7 +1311,7 @@ mod tests {
         m.insert(4, 42);
         m.insert(8, 42);
 
-        let keys = vec![1, 4, 8];
+        let keys = [1, 4, 8];
 
         for (key, value) in m.flat_iter_mut() {
             assert!(keys.contains(key));
@@ -1338,7 +1338,7 @@ mod tests {
         m.insert(4, 42);
         m.insert(8, 42);
 
-        let keys = vec![1, 4, 8];
+        let keys = [1, 4, 8];
 
         for (key, value) in &m {
             assert!(keys.contains(key));
@@ -1359,7 +1359,7 @@ mod tests {
         m.insert(4, 42);
         m.insert(8, 42);
 
-        let keys = vec![1, 4, 8];
+        let keys = [1, 4, 8];
 
         for (key, value) in &mut m {
             assert!(keys.contains(key));
@@ -1383,7 +1383,7 @@ mod tests {
         m.insert(4, 42);
         m.insert(8, 42);
 
-        let keys = vec![1, 4, 8];
+        let keys = [1, 4, 8];
 
         for (key, value) in m {
             assert!(keys.contains(&key));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,10 +254,10 @@ where
     /// assert_eq!(map.contains_key(&1), true);
     /// assert_eq!(map.contains_key(&2), false);
     /// ```
-    pub fn contains_key<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn contains_key<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         self.inner.contains_key(k)
     }
@@ -295,10 +295,10 @@ where
     /// assert_eq!(map.remove(&1), Some(vec![42, 1337]));
     /// assert_eq!(map.remove(&1), None);
     /// ```
-    pub fn remove<Q: ?Sized>(&mut self, k: &Q) -> Option<Vec<V>>
+    pub fn remove<Q>(&mut self, k: &Q) -> Option<Vec<V>>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         self.inner.remove(k)
     }
@@ -319,10 +319,10 @@ where
     /// map.insert(1, 1337);
     /// assert_eq!(map.get(&1), Some(&42));
     /// ```
-    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    pub fn get<Q>(&self, k: &Q) -> Option<&V>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         self.inner.get(k)?.get(0)
     }
@@ -346,10 +346,10 @@ where
     /// }
     /// assert_eq!(map[&1], 99);
     /// ```
-    pub fn get_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut V>
+    pub fn get_mut<Q>(&mut self, k: &Q) -> Option<&mut V>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         self.inner.get_mut(k)?.get_mut(0)
     }
@@ -369,10 +369,10 @@ where
     /// map.insert(1, 1337);
     /// assert_eq!(map.get_vec(&1), Some(&vec![42, 1337]));
     /// ```
-    pub fn get_vec<Q: ?Sized>(&self, k: &Q) -> Option<&Vec<V>>
+    pub fn get_vec<Q>(&self, k: &Q) -> Option<&Vec<V>>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         self.inner.get(k)
     }
@@ -396,10 +396,10 @@ where
     /// }
     /// assert_eq!(map.get_vec(&1), Some(&vec![1991, 2332]));
     /// ```
-    pub fn get_vec_mut<Q: ?Sized>(&mut self, k: &Q) -> Option<&mut Vec<V>>
+    pub fn get_vec_mut<Q>(&mut self, k: &Q) -> Option<&mut Vec<V>>
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         self.inner.get_mut(k)
     }
@@ -423,10 +423,10 @@ where
     /// assert_eq!(map.is_vec(&2), false);  // key is single-valued
     /// assert_eq!(map.is_vec(&3), false);  // key not in map
     /// ```
-    pub fn is_vec<Q: ?Sized>(&self, k: &Q) -> bool
+    pub fn is_vec<Q>(&self, k: &Q) -> bool
     where
         K: Borrow<Q>,
-        Q: Eq + Hash,
+        Q: Eq + Hash + ?Sized,
     {
         match self.get_vec(k) {
             Some(val) => val.len() > 1,
@@ -721,10 +721,10 @@ where
     }
 }
 
-impl<'a, K, V, S, Q: ?Sized> Index<&'a Q> for MultiMap<K, V, S>
+impl<'a, K, V, S, Q> Index<&'a Q> for MultiMap<K, V, S>
 where
     K: Eq + Hash + Borrow<Q>,
-    Q: Eq + Hash,
+    Q: Eq + Hash + ?Sized,
     S: BuildHasher,
 {
     type Output = V;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -721,7 +721,7 @@ where
     }
 }
 
-impl<'a, K, V, S, Q> Index<&'a Q> for MultiMap<K, V, S>
+impl<K, V, S, Q> Index<&Q> for MultiMap<K, V, S>
 where
     K: Eq + Hash + Borrow<Q>,
     Q: Eq + Hash + ?Sized,
@@ -936,7 +936,7 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for Iter<'a, K, V> {
+impl<K, V> ExactSizeIterator for Iter<'_, K, V> {
     fn len(&self) -> usize {
         self.inner.len()
     }
@@ -960,7 +960,7 @@ impl<'a, K, V> Iterator for IterMut<'a, K, V> {
     }
 }
 
-impl<'a, K, V> ExactSizeIterator for IterMut<'a, K, V> {
+impl<K, V> ExactSizeIterator for IterMut<'_, K, V> {
     fn len(&self) -> usize {
         self.inner.len()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ where
         K: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
     {
-        self.inner.get(k)?.get(0)
+        self.inner.get(k)?.first()
     }
 
     /// Returns a mutable reference to the first item in the vector corresponding to
@@ -761,7 +761,7 @@ where
         }
 
         self.iter_all()
-            .all(|(key, value)| other.get_vec(key).map_or(false, |v| *value == *v))
+            .all(|(key, value)| other.get_vec(key).is_some_and(|v| *value == *v))
     }
 }
 


### PR DESCRIPTION
Running `cargo clippy` was turning up several warnings. I split the fixes into different commits for readability.